### PR TITLE
Adding uv inline script metadata 

### DIFF
--- a/CVP_API/Snapshot_Utils/getSnapshots_Resource_API/get_snapshots_202x.py
+++ b/CVP_API/Snapshot_Utils/getSnapshots_Resource_API/get_snapshots_202x.py
@@ -1,3 +1,10 @@
+# /// script
+# requires-python = ">=3.12"
+# dependencies = ["requests","cloudvision","fuzzywuzzy","python-Levenshtein","xlrd"]
+# [tool.uv]
+# exclude-newer = "2024-10-01T00:00:00Z"
+# ///
+
 #!/usr/bin/env python3
 #
 # Copyright (c) 2021, Arista Networks, Inc.


### PR DESCRIPTION
As requirements.txt doesn't have dependencies versions pinned someone was able to install cloudvision packge version 1.0.0 and the script didn't work. Adding uv inline script metadata to install the newest version of the libraries that satisfy the dependency graph and do not violate the timestamp given. That will require uv to be used by whoever run the script.